### PR TITLE
UTC to timezone.utc

### DIFF
--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -2,7 +2,7 @@ import multiprocessing
 import platform
 import sys
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from functools import cache
 from pathlib import Path
 from typing import Any
@@ -129,7 +129,7 @@ def get_system_info() -> dict[str, str]:
         "platform": platform.platform(),
         "processor": platform.processor(),
         "cpu_count": str(multiprocessing.cpu_count()),
-        "timestamp": datetime.now(UTC).isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
 


### PR DESCRIPTION
UTC is from python 3.11, got error on 3.9 and 3.10.

## Summary by Sourcery

Bug Fixes:
- Fix compatibility issue with Python 3.9 and 3.10 by replacing 'UTC' with 'timezone.utc'.